### PR TITLE
Fix typo in main style sheet

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -13,7 +13,7 @@ h2, h3 {
 body {
     margin: 2em;
 }
-bady, input[text], button {
+body, input[text], button {
     color: #888;
     font-family: Cambria, Georgia;
 }


### PR DESCRIPTION
Typo was causing text to appear slightly differently than intended